### PR TITLE
Fix for Template::Reverse::Converter::TT2 documentation

### DIFF
--- a/lib/Template/Reverse.pm
+++ b/lib/Template/Reverse.pm
@@ -20,7 +20,7 @@ use Scalar::Util qw(blessed);
     my $parts = $rev->detect($arr_ref1, $arr_ref2); # returns [ Template::Reverser::Part, ... ]
 
     use Template::Reverse::Converter::TT2;
-    my @templates = Template::Reverse::TT2Converter::Convert($parts); 
+    my @templates = Template::Reverse::Converter::TT2::Convert($parts); 
 
 more
 

--- a/lib/Template/Reverse.pm
+++ b/lib/Template/Reverse.pm
@@ -20,7 +20,8 @@ use Scalar::Util qw(blessed);
     my $parts = $rev->detect($arr_ref1, $arr_ref2); # returns [ Template::Reverser::Part, ... ]
 
     use Template::Reverse::Converter::TT2;
-    my @templates = Template::Reverse::Converter::TT2::Convert($parts); 
+    my $converter = Template::Reverse::Converter::TT2->new();
+    my @templates = $converter->Convert($parts); 
 
 more
 


### PR DESCRIPTION
Using the code in the synopsis caused template generation to fail silently. This documentation correction fixed that for me.
